### PR TITLE
x11-misc/xlocatemouse: Add package

### DIFF
--- a/x11-misc/xlocatemouse/xlocatemouse-20.05.ebuild
+++ b/x11-misc/xlocatemouse/xlocatemouse-20.05.ebuild
@@ -26,7 +26,7 @@ IUSE=""
 
 DEPEND="x11-libs/libX11"
 RDEPEND="${DEPEND}"
-BDEPEND=""
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${P}-makefile.patch"

--- a/x11-misc/xlocatemouse/xlocatemouse-9999.ebuild
+++ b/x11-misc/xlocatemouse/xlocatemouse-9999.ebuild
@@ -26,7 +26,7 @@ IUSE=""
 
 DEPEND="x11-libs/libX11"
 RDEPEND="${DEPEND}"
-BDEPEND=""
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${P}-makefile.patch"


### PR DESCRIPTION
Adds xlocatemouse. The patch for live build isn't stable, but I don't want to install things into `/usr/local` either. It will have to be updated if the makefile changes.